### PR TITLE
Use async fs in backend, validate iLovePDF creds, improve filename sanitization and clipboard UX, add tests

### DIFF
--- a/backend/src/routes/compress.ts
+++ b/backend/src/routes/compress.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response, NextFunction } from "express";
 import multer from "multer";
-import fs from "fs";
+import { promises as fsp } from "fs";
 import os from "os";
 import { compressPdf } from "../utils/pdf/compress";
 
@@ -37,7 +37,7 @@ router.post(
     const newPath = `${req.file.path}.pdf`;
 
     try {
-      fs.renameSync(originalPath, newPath);
+      await fsp.rename(originalPath, newPath);
       console.log(`📂 Processing: ${newPath}`);
 
       const compressedBuffer = await compressPdf(newPath);
@@ -55,8 +55,7 @@ router.post(
         .json({ error: "Failed to process PDF", details: error.message });
     } finally {
       try {
-        if (fs.existsSync(newPath)) fs.unlinkSync(newPath);
-        else if (fs.existsSync(originalPath)) fs.unlinkSync(originalPath);
+        await Promise.allSettled([fsp.unlink(newPath), fsp.unlink(originalPath)]);
       } catch (e) {
         console.error("Cleanup error:", e);
       }

--- a/backend/src/utils/pdf/compress.ts
+++ b/backend/src/utils/pdf/compress.ts
@@ -2,9 +2,18 @@ import ILovePDFApi from "@ilovepdf/ilovepdf-nodejs";
 import ILovePDFFile from "@ilovepdf/ilovepdf-nodejs/ILovePDFFile";
 import path from "path";
 
+const publicKey = process.env.ILOVEPDF_PUBLIC_KEY;
+const secretKey = process.env.ILOVEPDF_SECRET_KEY;
+
+if (!publicKey || !secretKey) {
+  throw new Error(
+    "Missing iLovePDF credentials. Set ILOVEPDF_PUBLIC_KEY and ILOVEPDF_SECRET_KEY.",
+  );
+}
+
 const instance = new ILovePDFApi(
-  process.env.ILOVEPDF_PUBLIC_KEY!,
-  process.env.ILOVEPDF_SECRET_KEY!,
+  publicKey,
+  secretKey,
 );
 
 export async function compressPdf(filePath: string): Promise<Buffer> {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "test": "node --test --experimental-strip-types src/**/*.test.ts",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/frontend/src/components/FileList.tsx
+++ b/frontend/src/components/FileList.tsx
@@ -34,9 +34,16 @@ export const FileList = ({
 
   if (files.length === 0) return null;
 
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
-    toast.success("Nome copiado!");
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success("Nome copiado!");
+    } catch (error) {
+      console.error("Clipboard error:", error);
+      toast.error(
+        "Não foi possível copiar automaticamente. Copie manualmente.",
+      );
+    }
   };
 
   const startEditing = (file: ProcessedFile) => {

--- a/frontend/src/utils/fileSanitizer.test.ts
+++ b/frontend/src/utils/fileSanitizer.test.ts
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sanitizeFileName } from "./fileSanitizer.ts";
+
+test("mantém extensão e remove acentos/caracteres especiais", () => {
+  const sanitized = sanitizeFileName("Procuração do João (2024).PDF");
+  assert.equal(sanitized, "procuracao_do_joao_2024.pdf");
+});
+
+test("usa fallback quando nome-base fica vazio", () => {
+  const sanitized = sanitizeFileName("...pdf");
+  assert.equal(sanitized, "arquivo.pdf");
+});
+
+test("funciona sem extensão", () => {
+  const sanitized = sanitizeFileName("  ###  ");
+  assert.equal(sanitized, "arquivo");
+});

--- a/frontend/src/utils/fileSanitizer.ts
+++ b/frontend/src/utils/fileSanitizer.ts
@@ -2,14 +2,15 @@ export function sanitizeFileName(name: string): string {
   const lastDot = name.lastIndexOf(".");
   const ext = lastDot !== -1 ? name.slice(lastDot).toLowerCase() : "";
   const baseName = lastDot !== -1 ? name.slice(0, lastDot) : name;
+  const sanitizedBase = baseName
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "") // remove acentos
+    .replace(/[^a-zA-Z0-9_-]/g, "_") // substitui tudo que não for alfanumérico
+    .replace(/_+/g, "_") // colapsa múltiplos underscores
+    .replace(/^_+|_+$/g, "") // remove underscores no início e fim
+    .toLowerCase();
 
-  return (
-    baseName
-      .normalize("NFD")
-      .replace(/[\u0300-\u036f]/g, "") // remove acentos
-      .replace(/[^a-zA-Z0-9_-]/g, "_") // substitui tudo que não for alfanumérico
-      .replace(/_+/g, "_") // colapsa múltiplos underscores
-      .replace(/^_+|_+$/g, "") // remove underscores no início e fim
-      .toLowerCase() + ext
-  );
+  const safeBase = sanitizedBase || "arquivo";
+
+  return safeBase + ext;
 }


### PR DESCRIPTION
### Motivation

- Switch synchronous filesystem operations to async to avoid blocking the event loop and make cleanup more robust.
- Fail early when iLovePDF credentials are missing to surface configuration errors at startup.
- Improve filename sanitization and clipboard error handling in the frontend to provide a better user experience and predictable file names.

### Description

- Replaced `fs` sync calls with `fs.promises` in `backend/src/routes/compress.ts`, using `await fsp.rename` and `Promise.allSettled` for cleanup. 
- Added validation for `ILOVEPDF_PUBLIC_KEY` and `ILOVEPDF_SECRET_KEY` in `backend/src/utils/pdf/compress.ts` and switched to local `publicKey`/`secretKey` constants when initializing the `ILovePDFApi` instance.
- Made `copyToClipboard` in `frontend/src/components/FileList.tsx` async with `try/catch` and user-facing error toast on failure. 
- Hardened `sanitizeFileName` in `frontend/src/utils/fileSanitizer.ts` to normalize accents, collapse underscores, enforce lowercase, and fall back to `arquivo` when the base name becomes empty. 
- Added unit tests at `frontend/src/utils/fileSanitizer.test.ts` and a `test` script in `frontend/package.json` to run the new tests via `node --test`.

### Testing

- Ran the frontend tests with `node --test --experimental-strip-types src/**/*.test.ts`, which executed `frontend/src/utils/fileSanitizer.test.ts` and all assertions passed. 
- No automated backend tests were added or run as part of this change. 
- Type-check/build steps were not modified and were not part of the automated tests executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a0f4b440832e8bddb9a052a3c7e8)